### PR TITLE
fixed preview redirect issue when running netlify

### DIFF
--- a/pages/api/exitPreview.js
+++ b/pages/api/exitPreview.js
@@ -4,6 +4,7 @@ export default async (req, res) => {
 	res.clearPreviewData()
 
 	// Redirect to the slug
-	res.writeHead(307, { Location: req.query.slug })
+	//Add a dummy querystring to the location header - since Netlify will keep the QS for the incoming request by default
+	res.writeHead(307, { Location: `${req.query.slug}?preview=0` })
 	res.end()
 }

--- a/pages/api/preview.js
+++ b/pages/api/preview.js
@@ -29,7 +29,8 @@ export default async (req, res) => {
 	res.setPreviewData({})
 
 	// Redirect to the slug
-	res.writeHead(307, { Location: previewUrl })
+	//Add a dummy querystring to the location header - since Netlify will keep the QS for the incoming request by default
+	res.writeHead(307, { Location: `${previewUrl}?preview=1` })
 	res.end()
 
 }


### PR DESCRIPTION
This is a hack to fix an issue when running in Netlify which would retain querystrings when a request hit the /api/ endpoints for entering an exiting preview. This would result in an infinite redirect previously. 